### PR TITLE
bug: container instance availability zones modulus calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_container_instance_use_availability_zones"></a> [container\_instance\_use\_availability\_zones](#input\_container\_instance\_use\_availability\_zones)
+
+Description: Whether to use availability zones for the container instance
+
+Type: `bool`
+
+Default: `true`
+
 ### <a name="input_container_registry_creation_enabled"></a> [container\_registry\_creation\_enabled](#input\_container\_registry\_creation\_enabled)
 
 Description: Whether or not to create a container registry.

--- a/locals.container.instance.tf
+++ b/locals.container.instance.tf
@@ -2,7 +2,7 @@ locals {
   container_instances = {
     for instance in range(1, var.container_instance_count + 1) : instance => {
       name               = "${local.container_instance_name_prefix}-${instance}"
-      availability_zones = [instance % 3]
+      availability_zones = [(instance % 3) + 1]
     }
   }
 }

--- a/locals.container.instance.tf
+++ b/locals.container.instance.tf
@@ -1,6 +1,6 @@
 locals {
   container_instances = {
-    for instance in range(1, var.container_instance_count + 1) : instance => {
+    for instance in range(0, var.container_instance_count) : instance => {
       name               = "${local.container_instance_name_prefix}-${instance}"
       availability_zones = [(instance % 3) + 1]
     }

--- a/main.container.instance.tf
+++ b/main.container.instance.tf
@@ -14,7 +14,7 @@ module "container_instance" {
   sensitive_environment_variables   = local.container_instance_sensitive_environment_variables_map
   use_private_networking            = var.use_private_networking
   subnet_id                         = local.container_instance_subnet_id
-  availability_zones                = each.value.availability_zones
+  availability_zones                = var.container_instance_use_availability_zones ? each.value.availability_zones : null
   user_assigned_managed_identity_id = local.user_assigned_managed_identity_id
   container_registry_login_server   = local.registry_login_server
   container_registry_username       = var.custom_container_registry_username

--- a/modules/container-instance/README.md
+++ b/modules/container-instance/README.md
@@ -131,13 +131,7 @@ Description: List of availability zones
 
 Type: `list(string)`
 
-Default:
-
-```json
-[
-  1
-]
-```
+Default: `null`
 
 ### <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu)
 

--- a/modules/container-instance/variables.tf
+++ b/modules/container-instance/variables.tf
@@ -36,7 +36,7 @@ variable "user_assigned_managed_identity_id" {
 
 variable "availability_zones" {
   type        = list(string)
-  default     = [1]
+  default     = null
   description = "List of availability zones"
 }
 

--- a/variables.container.instance.tf
+++ b/variables.container.instance.tf
@@ -58,3 +58,9 @@ variable "container_instance_container_memory_limit" {
   description = "The memory limit value for the container instance"
   default     = 4
 }
+
+variable "container_instance_use_availability_zones" {
+  type        = bool
+  description = "Whether to use availability zones for the container instance"
+  default     = true
+}


### PR DESCRIPTION
## Description

Fix issue with container instance availability zones calc

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
