### PR TITLE
feat: add github app as authentication method for azure container app jobs 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ avm.tflint.merged.hcl
 avm.tflint_example.merged.hcl
 avm.tflint_module.hcl
 avm.tflint_module.merged.hcl
+examples/*/policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,25 @@ Type: `string`
 
 ### <a name="input_version_control_system_personal_access_token"></a> [version\_control\_system\_personal\_access\_token](#input\_version\_control\_system\_personal\_access\_token)
 
-Description: The personal access token for the version control system.
+Description: The personal access token for the version control system. Only required if `version_control_system_authentication_method` is set to `pat`.
+
+Type: `string`
+
+### <a name="input_version_control_system_github_application_key"></a> [version\_control\_system\_github\_application\_key](#input\_version\_control\_system\_github\_application\_key)
+
+Description: The GitHub application key to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
+
+Type: `string`
+
+### <a name="input_version_control_system_github_application_id"></a> [version\_control\_system\_github\_application\_id](#input\_version\_control\_system\_github\_application\_id)
+
+Description: The GitHub application ID to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
+
+Type: `string`
+
+### <a name="input_version_control_system_github_installation_id"></a> [version\_control\_system\_github\_installation\_id](#input\_version\_control\_system\_github\_installation\_id)
+
+Description: The GitHub installation ID to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
 
 Type: `string`
 
@@ -128,10 +146,16 @@ Type: `set(string)`
 Default:
 
 ```json
-[
-  "azure_container_app"
-]
+["azure_container_app"]
 ```
+
+### <a name="input_version_control_system_authentication_method"></a> [version\_control\_system\_authentication\_method](#input\_version\_control\_system\_authentication\_method)
+
+Description: The authentication method to use for the version control system. Allowed values are `pat` or `github_app`. `pat` is supported for both azuredevops and github while `github_app` can only be used for github.
+
+Type: `string`
+
+Default: `"pat"`
 
 ### <a name="input_container_app_container_cpu"></a> [container\_app\_container\_cpu](#input\_container\_app\_container\_cpu)
 

--- a/README.md
+++ b/README.md
@@ -103,30 +103,6 @@ Description: The version control system organization to deploy the agents too.
 
 Type: `string`
 
-### <a name="input_version_control_system_personal_access_token"></a> [version\_control\_system\_personal\_access\_token](#input\_version\_control\_system\_personal\_access\_token)
-
-Description: The personal access token for the version control system. Only required if `version_control_system_authentication_method` is set to `pat`.
-
-Type: `string`
-
-### <a name="input_version_control_system_github_application_key"></a> [version\_control\_system\_github\_application\_key](#input\_version\_control\_system\_github\_application\_key)
-
-Description: The GitHub application key to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
-
-Type: `string`
-
-### <a name="input_version_control_system_github_application_id"></a> [version\_control\_system\_github\_application\_id](#input\_version\_control\_system\_github\_application\_id)
-
-Description: The GitHub application ID to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
-
-Type: `string`
-
-### <a name="input_version_control_system_github_installation_id"></a> [version\_control\_system\_github\_installation\_id](#input\_version\_control\_system\_github\_installation\_id)
-
-Description: The GitHub installation ID to use for authentication. Only required if `version_control_system_authentication_method` is set to `github_app`.
-
-Type: `string`
-
 ### <a name="input_version_control_system_type"></a> [version\_control\_system\_type](#input\_version\_control\_system\_type)
 
 Description: The type of the version control system to deploy the agents too. Allowed values are 'azuredevops' or 'github'
@@ -146,16 +122,10 @@ Type: `set(string)`
 Default:
 
 ```json
-["azure_container_app"]
+[
+  "azure_container_app"
+]
 ```
-
-### <a name="input_version_control_system_authentication_method"></a> [version\_control\_system\_authentication\_method](#input\_version\_control\_system\_authentication\_method)
-
-Description: The authentication method to use for the version control system. Allowed values are `pat` or `github_app`. `pat` is supported for both azuredevops and github while `github_app` can only be used for github.
-
-Type: `string`
-
-Default: `"pat"`
 
 ### <a name="input_container_app_container_cpu"></a> [container\_app\_container\_cpu](#input\_container\_app\_container\_cpu)
 
@@ -884,6 +854,14 @@ Type: `number`
 
 Default: `1`
 
+### <a name="input_version_control_system_authentication_method"></a> [version\_control\_system\_authentication\_method](#input\_version\_control\_system\_authentication\_method)
+
+Description: GitHub authentication method. Possible values: pat or github\_app
+
+Type: `string`
+
+Default: `"pat"`
+
 ### <a name="input_version_control_system_enterprise"></a> [version\_control\_system\_enterprise](#input\_version\_control\_system\_enterprise)
 
 Description: The enterprise name for the version control system.
@@ -891,6 +869,38 @@ Description: The enterprise name for the version control system.
 Type: `string`
 
 Default: `null`
+
+### <a name="input_version_control_system_github_application_id"></a> [version\_control\_system\_github\_application\_id](#input\_version\_control\_system\_github\_application\_id)
+
+Description: The application ID for the GitHub App authentication method.
+
+Type: `string`
+
+Default: `""`
+
+### <a name="input_version_control_system_github_application_key"></a> [version\_control\_system\_github\_application\_key](#input\_version\_control\_system\_github\_application\_key)
+
+Description: The application key for the GitHub App authentication method.
+
+Type: `string`
+
+Default: `""`
+
+### <a name="input_version_control_system_github_installation_id"></a> [version\_control\_system\_github\_installation\_id](#input\_version\_control\_system\_github\_installation\_id)
+
+Description: The installation ID for the GitHub App authentication method.
+
+Type: `string`
+
+Default: `""`
+
+### <a name="input_version_control_system_personal_access_token"></a> [version\_control\_system\_personal\_access\_token](#input\_version\_control\_system\_personal\_access\_token)
+
+Description: The personal access token for the version control system.
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_version_control_system_placeholder_agent_name"></a> [version\_control\_system\_placeholder\_agent\_name](#input\_version\_control\_system\_placeholder\_agent\_name)
 

--- a/README.md
+++ b/README.md
@@ -884,7 +884,7 @@ Description: The application key for the GitHub App authentication method.
 
 Type: `string`
 
-Default: `""`
+Default: `null`
 
 ### <a name="input_version_control_system_github_installation_id"></a> [version\_control\_system\_github\_installation\_id](#input\_version\_control\_system\_github\_installation\_id)
 
@@ -900,7 +900,7 @@ Description: The personal access token for the version control system.
 
 Type: `string`
 
-Default: `""`
+Default: `null`
 
 ### <a name="input_version_control_system_placeholder_agent_name"></a> [version\_control\_system\_placeholder\_agent\_name](#input\_version\_control\_system\_placeholder\_agent\_name)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-Issues can be created and searched through for existing [issues here](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners/issues).
+Issues can be created and searched through for existing [issues here](../../issues).
 
 Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
 

--- a/avm
+++ b/avm
@@ -11,6 +11,8 @@ if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
     exit 1
 fi
 
+AVM_IMAGE=${AVM_IMAGE:-mcr.microsoft.com/azterraform}
+
 if [ -z "$1" ]; then
     echo "Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets."
     echo
@@ -18,16 +20,15 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-# Mount .azure directory if it exists
-AZURE_VOLUME=""
-if [ -d "$HOME/.azure" ]; then
-  AZURE_VOLUME="-v $HOME/.azure:/home/runtimeuser/.azure"
+# Check if AZURE_CONFIG_DIR is set, if not, set it to ~/.azure
+if [ -z "$AZURE_CONFIG_DIR" ]; then
+  AZURE_CONFIG_DIR="$HOME/.azure"
 fi
 
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm $AZURE_VOLUME -v "$(pwd)":/src -w /src -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"
+  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/avm.bat
+++ b/avm.bat
@@ -11,13 +11,21 @@ IF ERRORLEVEL 1 (
     exit /b
 )
 
+IF DEFINED AVM_IMAGE (SET "AVM_IMAGE=%AVM_IMAGE%") ELSE (SET "AVM_IMAGE=mcr.microsoft.com/azterraform")
+
 REM Check if a make target is provided
 IF "%~1"=="" (
     echo Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets.
     exit /b
 )
 
+IF DEFINED NO_PULL (
+    SET "PULL_ARG="
+) ELSE (
+    SET "PULL_ARG=--pull always"
+)
+
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run %PULL_ARG% --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER %AVM_IMAGE% make %1
 
 ENDLOCAL

--- a/examples/azure_devops_basic/README.md
+++ b/examples/azure_devops_basic/README.md
@@ -148,13 +148,18 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_basic/README.md
+++ b/examples/azure_devops_basic/README.md
@@ -4,9 +4,6 @@
 This example deploys Azure DevOps Agents to Azure Container Apps using the minimal set of required variables using private networking.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -148,9 +145,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -160,13 +154,7 @@ module "azure_devops_agents" {
   virtual_network_address_space                = "10.0.0.0/16"
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_basic/main.tf
+++ b/examples/azure_devops_basic/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -142,9 +139,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -154,13 +148,7 @@ module "azure_devops_agents" {
   virtual_network_address_space                = "10.0.0.0/16"
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_basic/main.tf
+++ b/examples/azure_devops_basic/main.tf
@@ -142,13 +142,18 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_bring_your_own_vnet/README.md
+++ b/examples/azure_devops_bring_your_own_vnet/README.md
@@ -186,7 +186,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -198,9 +204,11 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                      = local.selected_region
+  source = "../.."
+
+  location                                      = local.selected_region
   postfix                                       = random_string.name.result
   version_control_system_organization           = local.azure_devops_organization_url
-  version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_type                   = "azuredevops"
   compute_types                                 = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                       = module.virtual_network.subnets["container_app"].resource_id
@@ -208,7 +216,10 @@ module "azure_devops_agents" {
   container_registry_private_endpoint_subnet_id = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled               = false
   resource_group_name                           = azurerm_resource_group.this.name
+  resource_group_creation_enabled               = false
+  resource_group_name                           = azurerm_resource_group.this.name
   tags                                          = local.tags
+  version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name              = azuredevops_agent_pool.this.name
   virtual_network_creation_enabled              = false
   virtual_network_id                            = module.virtual_network.resource_id

--- a/examples/azure_devops_bring_your_own_vnet/README.md
+++ b/examples/azure_devops_bring_your_own_vnet/README.md
@@ -4,9 +4,6 @@
 This example deploys Azure DevOps Agents to Azure Container Apps and Azure Container Instance using private networking and bring your own virtual network.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -186,13 +183,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -201,9 +192,6 @@ module "virtual_network" {
 
 # This is the module call
 module "azure_devops_agents" {
-  source = "../.."
-
-  location                                      = local.selected_region
   source = "../.."
 
   location                                      = local.selected_region
@@ -216,8 +204,6 @@ module "azure_devops_agents" {
   container_registry_private_endpoint_subnet_id = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled               = false
   resource_group_name                           = azurerm_resource_group.this.name
-  resource_group_creation_enabled               = false
-  resource_group_name                           = azurerm_resource_group.this.name
   tags                                          = local.tags
   version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name              = azuredevops_agent_pool.this.name
@@ -226,10 +212,6 @@ module "azure_devops_agents" {
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_bring_your_own_vnet/main.tf
+++ b/examples/azure_devops_bring_your_own_vnet/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -180,13 +177,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -195,9 +186,6 @@ module "virtual_network" {
 
 # This is the module call
 module "azure_devops_agents" {
-  source = "../.."
-
-  location                                      = local.selected_region
   source = "../.."
 
   location                                      = local.selected_region
@@ -210,8 +198,6 @@ module "azure_devops_agents" {
   container_registry_private_endpoint_subnet_id = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled               = false
   resource_group_name                           = azurerm_resource_group.this.name
-  resource_group_creation_enabled               = false
-  resource_group_name                           = azurerm_resource_group.this.name
   tags                                          = local.tags
   version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name              = azuredevops_agent_pool.this.name
@@ -220,10 +206,6 @@ module "azure_devops_agents" {
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_bring_your_own_vnet/main.tf
+++ b/examples/azure_devops_bring_your_own_vnet/main.tf
@@ -180,7 +180,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -192,9 +198,11 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                      = local.selected_region
+  source = "../.."
+
+  location                                      = local.selected_region
   postfix                                       = random_string.name.result
   version_control_system_organization           = local.azure_devops_organization_url
-  version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_type                   = "azuredevops"
   compute_types                                 = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                       = module.virtual_network.subnets["container_app"].resource_id
@@ -202,7 +210,10 @@ module "azure_devops_agents" {
   container_registry_private_endpoint_subnet_id = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled               = false
   resource_group_name                           = azurerm_resource_group.this.name
+  resource_group_creation_enabled               = false
+  resource_group_name                           = azurerm_resource_group.this.name
   tags                                          = local.tags
+  version_control_system_personal_access_token  = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name              = azuredevops_agent_pool.this.name
   virtual_network_creation_enabled              = false
   virtual_network_id                            = module.virtual_network.resource_id

--- a/examples/azure_devops_bring_your_own_vnet_and_dns_zone/README.md
+++ b/examples/azure_devops_bring_your_own_vnet_and_dns_zone/README.md
@@ -186,7 +186,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -213,17 +219,18 @@ module "azure_devops_agents" {
   location                                             = local.selected_region
   postfix                                              = random_string.name.result
   version_control_system_organization                  = local.azure_devops_organization_url
-  version_control_system_personal_access_token         = var.azure_devops_agents_personal_access_token
   version_control_system_type                          = "azuredevops"
   compute_types                                        = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                              = module.virtual_network.subnets["container_app"].resource_id
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
+  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
   tags                                                 = local.tags
+  version_control_system_personal_access_token         = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name                     = azuredevops_agent_pool.this.name
   virtual_network_creation_enabled                     = false
   virtual_network_id                                   = module.virtual_network.resource_id

--- a/examples/azure_devops_bring_your_own_vnet_and_dns_zone/README.md
+++ b/examples/azure_devops_bring_your_own_vnet_and_dns_zone/README.md
@@ -186,13 +186,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -225,7 +219,6 @@ module "azure_devops_agents" {
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
-  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
@@ -237,10 +230,6 @@ module "azure_devops_agents" {
 
   depends_on = [azuredevops_pipeline_authorization.this, azurerm_private_dns_zone_virtual_network_link.container_registry]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_bring_your_own_vnet_and_dns_zone/main.tf
+++ b/examples/azure_devops_bring_your_own_vnet_and_dns_zone/main.tf
@@ -180,7 +180,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -207,7 +213,6 @@ module "azure_devops_agents" {
   location                                             = local.selected_region
   postfix                                              = random_string.name.result
   version_control_system_organization                  = local.azure_devops_organization_url
-  version_control_system_personal_access_token         = var.azure_devops_agents_personal_access_token
   version_control_system_type                          = "azuredevops"
   compute_types                                        = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                              = module.virtual_network.subnets["container_app"].resource_id
@@ -218,6 +223,7 @@ module "azure_devops_agents" {
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
   tags                                                 = local.tags
+  version_control_system_personal_access_token         = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name                     = azuredevops_agent_pool.this.name
   virtual_network_creation_enabled                     = false
   virtual_network_id                                   = module.virtual_network.resource_id

--- a/examples/azure_devops_bring_your_own_vnet_and_dns_zone/main.tf
+++ b/examples/azure_devops_bring_your_own_vnet_and_dns_zone/main.tf
@@ -180,13 +180,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -230,10 +224,6 @@ module "azure_devops_agents" {
 
   depends_on = [azuredevops_pipeline_authorization.this, azurerm_private_dns_zone_virtual_network_link.container_registry]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_container_instance/README.md
+++ b/examples/azure_devops_container_instance/README.md
@@ -125,14 +125,19 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   compute_types                                = ["azure_container_instance"]
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_container_instance/README.md
+++ b/examples/azure_devops_container_instance/README.md
@@ -4,9 +4,6 @@
 This example deploys Azure DevOps Agents to Azure Container Instance using the minimal set of required variables using private networking.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -125,9 +122,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -138,11 +132,7 @@ module "azure_devops_agents" {
   virtual_network_address_space                = "10.0.0.0/16"
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_container_instance/main.tf
+++ b/examples/azure_devops_container_instance/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -119,9 +116,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -132,11 +126,7 @@ module "azure_devops_agents" {
   virtual_network_address_space                = "10.0.0.0/16"
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_container_instance/main.tf
+++ b/examples/azure_devops_container_instance/main.tf
@@ -119,14 +119,19 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   compute_types                                = ["azure_container_instance"]
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_public_networking/README.md
+++ b/examples/azure_devops_public_networking/README.md
@@ -148,13 +148,18 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   tags                                         = local.tags
   use_private_networking                       = false
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_public_networking/README.md
+++ b/examples/azure_devops_public_networking/README.md
@@ -4,9 +4,6 @@
 This example deploys Azure DevOps Agents to Azure Container Apps using the minimal set of required variables with public networking.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -148,9 +145,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -160,13 +154,7 @@ module "azure_devops_agents" {
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/azure_devops_public_networking/main.tf
+++ b/examples/azure_devops_public_networking/main.tf
@@ -142,13 +142,18 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   tags                                         = local.tags
   use_private_networking                       = false
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
+
+  depends_on = [azuredevops_pipeline_authorization.this]
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }

--- a/examples/azure_devops_public_networking/main.tf
+++ b/examples/azure_devops_public_networking/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -142,9 +139,6 @@ module "azure_devops_agents" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -154,13 +148,7 @@ module "azure_devops_agents" {
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
 
   depends_on = [azuredevops_pipeline_authorization.this]
-
-  depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/github_basic/README.md
+++ b/examples/github_basic/README.md
@@ -6,6 +6,26 @@ This example deploys GitHub Runners to Azure Container Apps using the minimal se
 ```hcl
 
 
+variable "subscription_id" {
+  type        = string
+  description = "The subscription ID to use for the deployment."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
 
 locals {
   tags = {
@@ -37,6 +57,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = var.subscription_id
 }
 
 provider "github" {
@@ -108,17 +129,20 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source = "../.."
+  source                                        = "../.."
+  postfix                                       = random_string.name.result
+  location                                      = local.selected_region
+  version_control_system_type                   = "github"
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_organization           = var.github_organization_name
+  version_control_system_repository             = github_repository.this.name
+  virtual_network_address_space                 = "10.0.0.0/16"
 
-  location                                     = local.selected_region
-  postfix                                      = random_string.name.result
-  version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
-  version_control_system_type                  = "github"
-  tags                                         = local.tags
-  version_control_system_repository            = github_repository.this.name
-  virtual_network_address_space                = "10.0.0.0/16"
 
+  tags       = local.tags
   depends_on = [github_repository_file.this]
 }
 
@@ -189,9 +213,26 @@ Description: The personal access token used for authentication to GitHub.
 
 Type: `string`
 
-### <a name="input_github_runners_personal_access_token"></a> [github\_runners\_personal\_access\_token](#input\_github\_runners\_personal\_access\_token)
+### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
 
-Description: Personal access token for GitHub self-hosted runners (the token requires the 'repo' scope and should not expire).
+Description: The application key used for the GitHub App authentication method.
+Type: `string`
+
+### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
+
+Description: The application ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
+
+Description: The Installation ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id)
+
+Description: The subscription ID to use for the deployment.
 
 Type: `string`
 

--- a/examples/github_basic/README.md
+++ b/examples/github_basic/README.md
@@ -6,26 +6,9 @@ This example deploys GitHub Runners to Azure Container Apps using the minimal se
 ```hcl
 
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID to use for the deployment."
-}
 
-variable "github_application_key" {
-  type        = string
-  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
-  sensitive   = true
-}
 
-variable "github_application_id" {
-  type        = string
-  description = "The application ID used for the GitHub App authentication method."
-}
 
-variable "github_installation_id" {
-  type        = string
-  description = "The Installation ID used for the GitHub App authentication method."
-}
 
 locals {
   tags = {
@@ -129,20 +112,20 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source                                        = "../.."
-  postfix                                       = random_string.name.result
+  source = "../.."
+
   location                                      = local.selected_region
-  version_control_system_type                   = "github"
-  version_control_system_authentication_method  = "github_app"
-  version_control_system_github_application_key = var.github_application_key
-  version_control_system_github_application_id  = var.github_application_id
-  version_control_system_github_installation_id = var.github_installation_id
+  postfix                                       = random_string.name.result
   version_control_system_organization           = var.github_organization_name
+  version_control_system_type                   = "github"
+  tags                                          = local.tags
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_installation_id = var.github_installation_id
   version_control_system_repository             = github_repository.this.name
   virtual_network_address_space                 = "10.0.0.0/16"
 
-
-  tags       = local.tags
   depends_on = [github_repository_file.this]
 }
 
@@ -201,6 +184,24 @@ The following resources are used by this module:
 
 The following input variables are required:
 
+### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
+
+Description: The application ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
+
+Description: The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF\_VAR\_github\_application\_key = Get-Content path	o\[private\_key\_name].pem -Raw
+
+Type: `string`
+
+### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
+
+Description: The Installation ID used for the GitHub App authentication method.
+
+Type: `string`
+
 ### <a name="input_github_organization_name"></a> [github\_organization\_name](#input\_github\_organization\_name)
 
 Description: GitHub Organisation Name
@@ -210,23 +211,6 @@ Type: `string`
 ### <a name="input_github_personal_access_token"></a> [github\_personal\_access\_token](#input\_github\_personal\_access\_token)
 
 Description: The personal access token used for authentication to GitHub.
-
-Type: `string`
-
-### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
-
-Description: The application key used for the GitHub App authentication method.
-Type: `string`
-
-### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
-
-Description: The application ID used for the GitHub App authentication method.
-
-Type: `string`
-
-### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
-
-Description: The Installation ID used for the GitHub App authentication method.
 
 Type: `string`
 

--- a/examples/github_basic/main.tf
+++ b/examples/github_basic/main.tf
@@ -1,25 +1,8 @@
 
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID to use for the deployment."
-}
 
-variable "github_application_key" {
-  type        = string
-  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
-  sensitive   = true
-}
 
-variable "github_application_id" {
-  type        = string
-  description = "The application ID used for the GitHub App authentication method."
-}
 
-variable "github_installation_id" {
-  type        = string
-  description = "The Installation ID used for the GitHub App authentication method."
-}
 
 locals {
   tags = {
@@ -123,20 +106,20 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source                                        = "../.."
-  postfix                                       = random_string.name.result
+  source = "../.."
+
   location                                      = local.selected_region
-  version_control_system_type                   = "github"
-  version_control_system_authentication_method  = "github_app"
-  version_control_system_github_application_key = var.github_application_key
-  version_control_system_github_application_id  = var.github_application_id
-  version_control_system_github_installation_id = var.github_installation_id
+  postfix                                       = random_string.name.result
   version_control_system_organization           = var.github_organization_name
+  version_control_system_type                   = "github"
+  tags                                          = local.tags
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_installation_id = var.github_installation_id
   version_control_system_repository             = github_repository.this.name
   virtual_network_address_space                 = "10.0.0.0/16"
 
-
-  tags       = local.tags
   depends_on = [github_repository_file.this]
 }
 

--- a/examples/github_basic/main.tf
+++ b/examples/github_basic/main.tf
@@ -1,5 +1,25 @@
 
 
+variable "subscription_id" {
+  type        = string
+  description = "The subscription ID to use for the deployment."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
 
 locals {
   tags = {
@@ -31,6 +51,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = var.subscription_id
 }
 
 provider "github" {
@@ -102,17 +123,20 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source = "../.."
+  source                                        = "../.."
+  postfix                                       = random_string.name.result
+  location                                      = local.selected_region
+  version_control_system_type                   = "github"
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_organization           = var.github_organization_name
+  version_control_system_repository             = github_repository.this.name
+  virtual_network_address_space                 = "10.0.0.0/16"
 
-  location                                     = local.selected_region
-  postfix                                      = random_string.name.result
-  version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
-  version_control_system_type                  = "github"
-  tags                                         = local.tags
-  version_control_system_repository            = github_repository.this.name
-  virtual_network_address_space                = "10.0.0.0/16"
 
+  tags       = local.tags
   depends_on = [github_repository_file.this]
 }
 

--- a/examples/github_basic/variables.tf
+++ b/examples/github_basic/variables.tf
@@ -1,3 +1,19 @@
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
+
 variable "github_organization_name" {
   type        = string
   description = "GitHub Organisation Name"
@@ -9,8 +25,7 @@ variable "github_personal_access_token" {
   sensitive   = true
 }
 
-variable "github_runners_personal_access_token" {
+variable "subscription_id" {
   type        = string
-  description = "Personal access token for GitHub self-hosted runners (the token requires the 'repo' scope and should not expire)."
-  sensitive   = true
+  description = "The subscription ID to use for the deployment."
 }

--- a/examples/github_bring_your_own_vnet_and_dns_zone/README.md
+++ b/examples/github_bring_your_own_vnet_and_dns_zone/README.md
@@ -148,7 +148,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -175,17 +181,18 @@ module "azure_devops_agents" {
   location                                             = local.selected_region
   postfix                                              = random_string.name.result
   version_control_system_organization                  = var.github_organization_name
-  version_control_system_personal_access_token         = var.github_runners_personal_access_token
   version_control_system_type                          = "github"
   compute_types                                        = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                              = module.virtual_network.subnets["container_app"].resource_id
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
+  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
   tags                                                 = local.tags
+  version_control_system_personal_access_token         = var.github_runners_personal_access_token
   version_control_system_repository                    = github_repository.this.name
   virtual_network_creation_enabled                     = false
   virtual_network_id                                   = module.virtual_network.resource_id

--- a/examples/github_bring_your_own_vnet_and_dns_zone/README.md
+++ b/examples/github_bring_your_own_vnet_and_dns_zone/README.md
@@ -4,9 +4,6 @@
 This example deploys GitHub Runners to Azure Container Apps and Azure Container Instance using private networking and bring your own virtual network and DNS zone.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -148,13 +145,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -187,7 +178,6 @@ module "azure_devops_agents" {
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
-  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
@@ -199,10 +189,6 @@ module "azure_devops_agents" {
 
   depends_on = [azurerm_private_dns_zone_virtual_network_link.container_registry]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/github_bring_your_own_vnet_and_dns_zone/main.tf
+++ b/examples/github_bring_your_own_vnet_and_dns_zone/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -142,13 +139,7 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
-  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.7.1"
-
   address_space       = [local.virtual_network_address_space]
-  location            = local.selected_region
-  resource_group_name = azurerm_resource_group.this.name
-  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -181,7 +172,6 @@ module "azure_devops_agents" {
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
-  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
@@ -193,10 +183,6 @@ module "azure_devops_agents" {
 
   depends_on = [azurerm_private_dns_zone_virtual_network_link.container_registry]
 }
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/github_bring_your_own_vnet_and_dns_zone/main.tf
+++ b/examples/github_bring_your_own_vnet_and_dns_zone/main.tf
@@ -142,7 +142,13 @@ module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "0.7.1"
 
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "0.7.1"
+
   address_space       = [local.virtual_network_address_space]
+  location            = local.selected_region
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "vnet-${random_string.name.result}"
   location            = local.selected_region
   resource_group_name = azurerm_resource_group.this.name
   name                = "vnet-${random_string.name.result}"
@@ -169,17 +175,18 @@ module "azure_devops_agents" {
   location                                             = local.selected_region
   postfix                                              = random_string.name.result
   version_control_system_organization                  = var.github_organization_name
-  version_control_system_personal_access_token         = var.github_runners_personal_access_token
   version_control_system_type                          = "github"
   compute_types                                        = ["azure_container_app", "azure_container_instance"]
   container_app_subnet_id                              = module.virtual_network.subnets["container_app"].resource_id
   container_instance_subnet_id                         = module.virtual_network.subnets["container_instance"].resource_id
   container_registry_dns_zone_id                       = azurerm_private_dns_zone.container_registry.id
   container_registry_private_dns_zone_creation_enabled = false
+  container_registry_private_dns_zone_creation_enabled = false
   container_registry_private_endpoint_subnet_id        = module.virtual_network.subnets["container_registry_private_endpoint"].resource_id
   resource_group_creation_enabled                      = false
   resource_group_name                                  = azurerm_resource_group.this.name
   tags                                                 = local.tags
+  version_control_system_personal_access_token         = var.github_runners_personal_access_token
   version_control_system_repository                    = github_repository.this.name
   virtual_network_creation_enabled                     = false
   virtual_network_id                                   = module.virtual_network.resource_id

--- a/examples/github_container_instance/README.md
+++ b/examples/github_container_instance/README.md
@@ -88,14 +88,19 @@ module "github_runners" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_type                  = "github"
   compute_types                                = ["azure_container_instance"]
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_repository            = github_repository.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [github_repository_file.this]
 
   depends_on = [github_repository_file.this]
 }

--- a/examples/github_container_instance/README.md
+++ b/examples/github_container_instance/README.md
@@ -4,9 +4,6 @@
 This example deploys GitHub Runners to Azure Container Instance using the minimal set of required variables using private networking.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -88,9 +85,6 @@ module "github_runners" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = var.github_organization_name
   version_control_system_type                  = "github"
@@ -99,8 +93,6 @@ module "github_runners" {
   version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_repository            = github_repository.this.name
   virtual_network_address_space                = "10.0.0.0/16"
-
-  depends_on = [github_repository_file.this]
 
   depends_on = [github_repository_file.this]
 }

--- a/examples/github_container_instance/main.tf
+++ b/examples/github_container_instance/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -82,9 +79,6 @@ module "github_runners" {
   source = "../.."
 
   location                                     = local.selected_region
-  source = "../.."
-
-  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = var.github_organization_name
   version_control_system_type                  = "github"
@@ -93,8 +87,6 @@ module "github_runners" {
   version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_repository            = github_repository.this.name
   virtual_network_address_space                = "10.0.0.0/16"
-
-  depends_on = [github_repository_file.this]
 
   depends_on = [github_repository_file.this]
 }

--- a/examples/github_container_instance/main.tf
+++ b/examples/github_container_instance/main.tf
@@ -82,14 +82,19 @@ module "github_runners" {
   source = "../.."
 
   location                                     = local.selected_region
+  source = "../.."
+
+  location                                     = local.selected_region
   postfix                                      = random_string.name.result
   version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_type                  = "github"
   compute_types                                = ["azure_container_instance"]
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.github_runners_personal_access_token
   version_control_system_repository            = github_repository.this.name
   virtual_network_address_space                = "10.0.0.0/16"
+
+  depends_on = [github_repository_file.this]
 
   depends_on = [github_repository_file.this]
 }

--- a/examples/github_public_networking/README.md
+++ b/examples/github_public_networking/README.md
@@ -6,6 +6,26 @@ This example deploys GitHub Runners to Azure Container Apps using the minimal se
 ```hcl
 
 
+variable "subscription_id" {
+  type        = string
+  description = "The subscription ID to use for the deployment."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
 
 locals {
   tags = {
@@ -37,6 +57,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = var.subscription_id
 }
 
 provider "github" {
@@ -108,18 +129,19 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source = "../.."
-
-  location                                     = local.selected_region
-  postfix                                      = random_string.name.result
-  version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
-  version_control_system_type                  = "github"
-  tags                                         = local.tags
-  use_private_networking                       = false
-  version_control_system_repository            = github_repository.this.name
-
-  depends_on = [github_repository_file.this]
+  source                                        = "../.."
+  postfix                                       = random_string.name.result
+  location                                      = local.selected_region
+  version_control_system_type                   = "github"
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_organization           = var.github_organization_name
+  version_control_system_repository             = github_repository.this.name
+  use_private_networking                        = false
+  tags                                          = local.tags
+  depends_on                                    = [github_repository_file.this]
 }
 
 # Region helpers
@@ -189,9 +211,26 @@ Description: The personal access token used for authentication to GitHub.
 
 Type: `string`
 
-### <a name="input_github_runners_personal_access_token"></a> [github\_runners\_personal\_access\_token](#input\_github\_runners\_personal\_access\_token)
+### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
 
-Description: Personal access token for GitHub self-hosted runners (the token requires the 'repo' scope and should not expire).
+Description: The application key used for the GitHub App authentication method.
+Type: `string`
+
+### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
+
+Description: The application ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
+
+Description: The Installation ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id)
+
+Description: The subscription ID to use for the deployment.
 
 Type: `string`
 

--- a/examples/github_public_networking/README.md
+++ b/examples/github_public_networking/README.md
@@ -6,26 +6,9 @@ This example deploys GitHub Runners to Azure Container Apps using the minimal se
 ```hcl
 
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID to use for the deployment."
-}
 
-variable "github_application_key" {
-  type        = string
-  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
-  sensitive   = true
-}
 
-variable "github_application_id" {
-  type        = string
-  description = "The application ID used for the GitHub App authentication method."
-}
 
-variable "github_installation_id" {
-  type        = string
-  description = "The Installation ID used for the GitHub App authentication method."
-}
 
 locals {
   tags = {
@@ -129,19 +112,21 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source                                        = "../.."
-  postfix                                       = random_string.name.result
+  source = "../.."
+
   location                                      = local.selected_region
-  version_control_system_type                   = "github"
-  version_control_system_authentication_method  = "github_app"
-  version_control_system_github_application_key = var.github_application_key
-  version_control_system_github_application_id  = var.github_application_id
-  version_control_system_github_installation_id = var.github_installation_id
+  postfix                                       = random_string.name.result
   version_control_system_organization           = var.github_organization_name
-  version_control_system_repository             = github_repository.this.name
-  use_private_networking                        = false
+  version_control_system_type                   = "github"
   tags                                          = local.tags
-  depends_on                                    = [github_repository_file.this]
+  use_private_networking                        = false
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_repository             = github_repository.this.name
+
+  depends_on = [github_repository_file.this]
 }
 
 # Region helpers
@@ -199,6 +184,24 @@ The following resources are used by this module:
 
 The following input variables are required:
 
+### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
+
+Description: The application ID used for the GitHub App authentication method.
+
+Type: `string`
+
+### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
+
+Description: The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF\_VAR\_github\_application\_key = Get-Content path	o\[private\_key\_name].pem -Raw
+
+Type: `string`
+
+### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
+
+Description: The Installation ID used for the GitHub App authentication method.
+
+Type: `string`
+
 ### <a name="input_github_organization_name"></a> [github\_organization\_name](#input\_github\_organization\_name)
 
 Description: GitHub Organisation Name
@@ -208,23 +211,6 @@ Type: `string`
 ### <a name="input_github_personal_access_token"></a> [github\_personal\_access\_token](#input\_github\_personal\_access\_token)
 
 Description: The personal access token used for authentication to GitHub.
-
-Type: `string`
-
-### <a name="input_github_application_key"></a> [github\_application\_key](#input\_github\_application\_key)
-
-Description: The application key used for the GitHub App authentication method.
-Type: `string`
-
-### <a name="input_github_application_id"></a> [github\_application\_id](#input\_github\_application\_id)
-
-Description: The application ID used for the GitHub App authentication method.
-
-Type: `string`
-
-### <a name="input_github_installation_id"></a> [github\_installation\_id](#input\_github\_installation\_id)
-
-Description: The Installation ID used for the GitHub App authentication method.
 
 Type: `string`
 

--- a/examples/github_public_networking/main.tf
+++ b/examples/github_public_networking/main.tf
@@ -1,5 +1,25 @@
 
 
+variable "subscription_id" {
+  type        = string
+  description = "The subscription ID to use for the deployment."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
 
 locals {
   tags = {
@@ -31,6 +51,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = var.subscription_id
 }
 
 provider "github" {
@@ -102,18 +123,19 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source = "../.."
-
-  location                                     = local.selected_region
-  postfix                                      = random_string.name.result
-  version_control_system_organization          = var.github_organization_name
-  version_control_system_personal_access_token = var.github_runners_personal_access_token
-  version_control_system_type                  = "github"
-  tags                                         = local.tags
-  use_private_networking                       = false
-  version_control_system_repository            = github_repository.this.name
-
-  depends_on = [github_repository_file.this]
+  source                                        = "../.."
+  postfix                                       = random_string.name.result
+  location                                      = local.selected_region
+  version_control_system_type                   = "github"
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_organization           = var.github_organization_name
+  version_control_system_repository             = github_repository.this.name
+  use_private_networking                        = false
+  tags                                          = local.tags
+  depends_on                                    = [github_repository_file.this]
 }
 
 # Region helpers

--- a/examples/github_public_networking/main.tf
+++ b/examples/github_public_networking/main.tf
@@ -1,25 +1,8 @@
 
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID to use for the deployment."
-}
 
-variable "github_application_key" {
-  type        = string
-  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
-  sensitive   = true
-}
 
-variable "github_application_id" {
-  type        = string
-  description = "The application ID used for the GitHub App authentication method."
-}
 
-variable "github_installation_id" {
-  type        = string
-  description = "The Installation ID used for the GitHub App authentication method."
-}
 
 locals {
   tags = {
@@ -123,19 +106,21 @@ resource "azapi_resource_action" "resource_provider_registration" {
 
 # This is the module call
 module "github_runners" {
-  source                                        = "../.."
-  postfix                                       = random_string.name.result
+  source = "../.."
+
   location                                      = local.selected_region
-  version_control_system_type                   = "github"
-  version_control_system_authentication_method  = "github_app"
-  version_control_system_github_application_key = var.github_application_key
-  version_control_system_github_application_id  = var.github_application_id
-  version_control_system_github_installation_id = var.github_installation_id
+  postfix                                       = random_string.name.result
   version_control_system_organization           = var.github_organization_name
-  version_control_system_repository             = github_repository.this.name
-  use_private_networking                        = false
+  version_control_system_type                   = "github"
   tags                                          = local.tags
-  depends_on                                    = [github_repository_file.this]
+  use_private_networking                        = false
+  version_control_system_authentication_method  = "github_app"
+  version_control_system_github_application_id  = var.github_application_id
+  version_control_system_github_application_key = var.github_application_key
+  version_control_system_github_installation_id = var.github_installation_id
+  version_control_system_repository             = github_repository.this.name
+
+  depends_on = [github_repository_file.this]
 }
 
 # Region helpers

--- a/examples/github_public_networking/variables.tf
+++ b/examples/github_public_networking/variables.tf
@@ -1,3 +1,19 @@
+variable "github_application_id" {
+  type        = string
+  description = "The application ID used for the GitHub App authentication method."
+}
+
+variable "github_application_key" {
+  type        = string
+  description = "The application key used for the GitHub App authentication method. Import key file as environment variable: $env:TF_VAR_github_application_key = Get-Content path\to\\[private_key_name].pem -Raw"
+  sensitive   = true
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "The Installation ID used for the GitHub App authentication method."
+}
+
 variable "github_organization_name" {
   type        = string
   description = "GitHub Organisation Name"
@@ -9,8 +25,7 @@ variable "github_personal_access_token" {
   sensitive   = true
 }
 
-variable "github_runners_personal_access_token" {
+variable "subscription_id" {
   type        = string
-  description = "Personal access token for GitHub self-hosted runners (the token requires the 'repo' scope and should not expire)."
-  sensitive   = true
+  description = "The subscription ID to use for the deployment."
 }

--- a/examples/multi_region/README.md
+++ b/examples/multi_region/README.md
@@ -6,9 +6,6 @@ This example deploys Azure DevOps Agents to Azure Container Apps using the minim
 >NOTE: Multi-region support may result in duplicated agent scaling, there is no built-in mechanism to prevent this.
 
 ```hcl
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -155,9 +152,6 @@ module "azure_devops_agents_primary" {
   source = "../.."
 
   location                                     = local.selected_region_primary
-  source = "../.."
-
-  location                                     = local.selected_region_primary
   postfix                                      = "${random_string.name.result}1"
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -174,9 +168,6 @@ module "azure_devops_agents_secondary" {
   source = "../.."
 
   location                                     = local.selected_region_secondary
-  source = "../.."
-
-  location                                     = local.selected_region_secondary
   postfix                                      = "${random_string.name.result}2"
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -188,16 +179,6 @@ module "azure_devops_agents_secondary" {
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
-
-
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/examples/multi_region/README.md
+++ b/examples/multi_region/README.md
@@ -155,12 +155,15 @@ module "azure_devops_agents_primary" {
   source = "../.."
 
   location                                     = local.selected_region_primary
+  source = "../.."
+
+  location                                     = local.selected_region_primary
   postfix                                      = "${random_string.name.result}1"
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   container_app_polling_interval_seconds       = local.primary_polling_interval_prime_number
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
 
@@ -171,12 +174,15 @@ module "azure_devops_agents_secondary" {
   source = "../.."
 
   location                                     = local.selected_region_secondary
+  source = "../.."
+
+  location                                     = local.selected_region_secondary
   postfix                                      = "${random_string.name.result}2"
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   container_app_polling_interval_seconds       = local.secondary_polling_interval_prime_number
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.1.0.0/16"
 

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -147,12 +147,15 @@ module "azure_devops_agents_primary" {
   source = "../.."
 
   location                                     = local.selected_region_primary
+  source = "../.."
+
+  location                                     = local.selected_region_primary
   postfix                                      = "${random_string.name.result}1"
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   container_app_polling_interval_seconds       = local.primary_polling_interval_prime_number
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.0.0.0/16"
 
@@ -163,12 +166,15 @@ module "azure_devops_agents_secondary" {
   source = "../.."
 
   location                                     = local.selected_region_secondary
+  source = "../.."
+
+  location                                     = local.selected_region_secondary
   postfix                                      = "${random_string.name.result}2"
   version_control_system_organization          = local.azure_devops_organization_url
-  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_type                  = "azuredevops"
   container_app_polling_interval_seconds       = local.secondary_polling_interval_prime_number
   tags                                         = local.tags
+  version_control_system_personal_access_token = var.azure_devops_agents_personal_access_token
   version_control_system_pool_name             = azuredevops_agent_pool.this.name
   virtual_network_address_space                = "10.1.0.0/16"
 

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -1,6 +1,3 @@
-
-
-
 locals {
   tags = {
     scenario = "default"
@@ -147,9 +144,6 @@ module "azure_devops_agents_primary" {
   source = "../.."
 
   location                                     = local.selected_region_primary
-  source = "../.."
-
-  location                                     = local.selected_region_primary
   postfix                                      = "${random_string.name.result}1"
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -166,9 +160,6 @@ module "azure_devops_agents_secondary" {
   source = "../.."
 
   location                                     = local.selected_region_secondary
-  source = "../.."
-
-  location                                     = local.selected_region_secondary
   postfix                                      = "${random_string.name.result}2"
   version_control_system_organization          = local.azure_devops_organization_url
   version_control_system_type                  = "azuredevops"
@@ -180,16 +171,6 @@ module "azure_devops_agents_secondary" {
 
   depends_on = [azuredevops_pipeline_authorization.this]
 }
-
-
-
-
-
-
-
-
-
-
 
 # Region helpers
 module "regions" {

--- a/locals.container.app.job.tf
+++ b/locals.container.app.job.tf
@@ -5,11 +5,18 @@ locals {
     targetPipelinesQueueLength = var.version_control_system_agent_target_queue_length
   }
   keda_meta_data_final = var.version_control_system_type == local.version_control_system_azure_devops ? jsonencode(local.keda_meta_data_azure_devops) : jsonencode(local.keda_meta_data_github)
-  keda_meta_data_github = {
+  keda_meta_data_github = var.version_control_system_authentication_method == "pat" ? {
     owner                     = var.version_control_system_organization
     repos                     = var.version_control_system_repository
     targetWorkflowQueueLength = var.version_control_system_agent_target_queue_length
     runnerScope               = var.version_control_system_runner_scope
+    } : {
+    owner                     = var.version_control_system_organization
+    repos                     = var.version_control_system_repository
+    targetWorkflowQueueLength = var.version_control_system_agent_target_queue_length
+    runnerScope               = var.version_control_system_runner_scope
+    applicationID             = var.version_control_system_github_application_id
+    installationID            = var.version_control_system_github_installation_id
   }
 }
 
@@ -26,7 +33,7 @@ locals {
     }
   ]
   environment_variables_final = var.version_control_system_type == local.version_control_system_azure_devops ? jsonencode(local.environment_variables_azure_devops) : jsonencode(local.environment_variables_github)
-  environment_variables_github = [
+  environment_variables_github = var.version_control_system_authentication_method == "pat" ? [
     {
       name  = "RUNNER_NAME_PREFIX"
       value = local.version_control_system_agent_name_prefix
@@ -54,6 +61,39 @@ locals {
     {
       name  = "RUNNER_GROUP"
       value = var.version_control_system_runner_group
+    }
+    ] : [
+    {
+      name  = "RUNNER_NAME_PREFIX"
+      value = local.version_control_system_agent_name_prefix
+    },
+    {
+      name  = "REPO_URL"
+      value = local.github_repository_url
+    },
+    {
+      name  = "RUNNER_SCOPE"
+      value = var.version_control_system_runner_scope
+    },
+    {
+      name  = "EPHEMERAL"
+      value = "true"
+    },
+    {
+      name  = "ORG_NAME"
+      value = var.version_control_system_organization
+    },
+    {
+      name  = "ENTERPRISE_NAME"
+      value = var.version_control_system_enterprise
+    },
+    {
+      name  = "RUNNER_GROUP"
+      value = var.version_control_system_runner_group
+    },
+    {
+      name  = "APP_ID"
+      value = var.version_control_system_github_application_id
     }
   ]
 }
@@ -91,12 +131,19 @@ locals {
     }
   ]
   sensitive_environment_variables_final = var.version_control_system_type == local.version_control_system_azure_devops ? jsonencode(local.sensitive_environment_variables_azure_devops) : jsonencode(local.sensitive_environment_variables_github)
-  sensitive_environment_variables_github = [
+  sensitive_environment_variables_github = var.version_control_system_authentication_method == "pat" ? [
     {
       name                      = "ACCESS_TOKEN"
       value                     = var.version_control_system_personal_access_token
       container_app_secret_name = "personal-access-token"
       keda_auth_name            = "personalAccessToken"
+    }
+    ] : [
+    {
+      name                      = "APP_PRIVATE_KEY"
+      value                     = var.version_control_system_github_application_key
+      container_app_secret_name = "application-key"
+      keda_auth_name            = "appKey"
     }
   ]
 }

--- a/modules/container-registry/README.md
+++ b/modules/container-registry/README.md
@@ -13,6 +13,14 @@ module "container_registry" {
   resource_group_name        = var.resource_group_name
   enable_telemetry           = var.enable_telemetry
   network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
+  source  = "Azure/avm-res-containerregistry-registry/azurerm"
+  version = "0.4.0"
+
+  location                   = var.location
+  name                       = var.name
+  resource_group_name        = var.resource_group_name
+  enable_telemetry           = var.enable_telemetry
+  network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
   private_endpoints = var.use_private_networking ? {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zone_id == null || var.private_dns_zone_id == "" ? [] : [var.private_dns_zone_id]

--- a/modules/container-registry/README.md
+++ b/modules/container-registry/README.md
@@ -13,14 +13,6 @@ module "container_registry" {
   resource_group_name        = var.resource_group_name
   enable_telemetry           = var.enable_telemetry
   network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
-  source  = "Azure/avm-res-containerregistry-registry/azurerm"
-  version = "0.4.0"
-
-  location                   = var.location
-  name                       = var.name
-  resource_group_name        = var.resource_group_name
-  enable_telemetry           = var.enable_telemetry
-  network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
   private_endpoints = var.use_private_networking ? {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zone_id == null || var.private_dns_zone_id == "" ? [] : [var.private_dns_zone_id]

--- a/modules/container-registry/main.tf
+++ b/modules/container-registry/main.tf
@@ -7,6 +7,14 @@ module "container_registry" {
   resource_group_name        = var.resource_group_name
   enable_telemetry           = var.enable_telemetry
   network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
+  source  = "Azure/avm-res-containerregistry-registry/azurerm"
+  version = "0.4.0"
+
+  location                   = var.location
+  name                       = var.name
+  resource_group_name        = var.resource_group_name
+  enable_telemetry           = var.enable_telemetry
+  network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
   private_endpoints = var.use_private_networking ? {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zone_id == null || var.private_dns_zone_id == "" ? [] : [var.private_dns_zone_id]

--- a/modules/container-registry/main.tf
+++ b/modules/container-registry/main.tf
@@ -7,14 +7,6 @@ module "container_registry" {
   resource_group_name        = var.resource_group_name
   enable_telemetry           = var.enable_telemetry
   network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
-  source  = "Azure/avm-res-containerregistry-registry/azurerm"
-  version = "0.4.0"
-
-  location                   = var.location
-  name                       = var.name
-  resource_group_name        = var.resource_group_name
-  enable_telemetry           = var.enable_telemetry
-  network_rule_bypass_option = var.use_private_networking ? "AzureServices" : "None"
   private_endpoints = var.use_private_networking ? {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zone_id == null || var.private_dns_zone_id == "" ? [] : [var.private_dns_zone_id]

--- a/variables.version.control.system.tf
+++ b/variables.version.control.system.tf
@@ -3,74 +3,6 @@ variable "version_control_system_organization" {
   description = "The version control system organization to deploy the agents too."
 }
 
-variable "version_control_system_personal_access_token" {
-  type        = string
-  description = "The personal access token for the version control system."
-  sensitive   = true
-  default     = ""
-
-  validation {
-    condition = (
-      var.version_control_system_authentication_method == "pat" ? length(var.version_control_system_personal_access_token) > 0 : true
-    )
-    error_message = "Variable version_control_system_personal_access_token must be defined when version_control_system_authentication_method is pat."
-  }
-}
-
-variable "version_control_system_github_application_key" {
-  type        = string
-  description = "The application key for the GitHub App authentication method."
-  sensitive   = true
-  default     = ""
-
-  validation {
-    condition = (
-      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_key) > 0 : true
-    )
-    error_message = "Variable version_control_system_github_application_key must be defined when version_control_system_authentication_method is github_app."
-  }
-}
-
-variable "version_control_system_github_application_id" {
-  type        = string
-  default     = ""
-  description = "The application ID for the GitHub App authentication method."
-
-  validation {
-    condition = (
-      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_id) > 0 : true
-    )
-    error_message = "Variable version_control_system_github_application_id must be defined when version_control_system_authentication_method is github_app."
-  }
-}
-
-variable "version_control_system_github_installation_id" {
-  type        = string
-  default     = ""
-  description = "The installation ID for the GitHub App authentication method."
-
-  validation {
-    condition = (
-      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_installation_id) > 0 : true
-    )
-    error_message = "Variable version_control_system_github_installation_id must be defined when version_control_system_authentication_method is github_app."
-  }
-}
-
-variable "version_control_system_authentication_method" {
-  type        = string
-  default     = "pat"
-  description = "GitHub authentication method. Possible values: pat or github_app"
-
-  validation {
-    condition = (
-      var.version_control_system_type == "azuredevops" ? var.version_control_system_authentication_method == "pat" :
-      var.version_control_system_authentication_method == "pat" || var.version_control_system_authentication_method == "github_app"
-    )
-    error_message = "azuredevops and github both support only pat while github_app is only supported for github."
-  }
-}
-
 variable "version_control_system_type" {
   type        = string
   description = "The type of the version control system to deploy the agents too. Allowed values are 'azuredevops' or 'github'"
@@ -94,10 +26,78 @@ variable "version_control_system_agent_target_queue_length" {
   description = "The target value for the amound of pending jobs to scale on."
 }
 
+variable "version_control_system_authentication_method" {
+  type        = string
+  default     = "pat"
+  description = "GitHub authentication method. Possible values: pat or github_app"
+
+  validation {
+    condition = (
+      var.version_control_system_type == "azuredevops" ? var.version_control_system_authentication_method == "pat" :
+      var.version_control_system_authentication_method == "pat" || var.version_control_system_authentication_method == "github_app"
+    )
+    error_message = "azuredevops and github both support only pat while github_app is only supported for github."
+  }
+}
+
 variable "version_control_system_enterprise" {
   type        = string
   default     = null
   description = "The enterprise name for the version control system."
+}
+
+variable "version_control_system_github_application_id" {
+  type        = string
+  default     = ""
+  description = "The application ID for the GitHub App authentication method."
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_id) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_application_id must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_github_application_key" {
+  type        = string
+  default     = ""
+  description = "The application key for the GitHub App authentication method."
+  sensitive   = true
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_key) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_application_key must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_github_installation_id" {
+  type        = string
+  default     = ""
+  description = "The installation ID for the GitHub App authentication method."
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_installation_id) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_installation_id must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_personal_access_token" {
+  type        = string
+  default     = ""
+  description = "The personal access token for the version control system."
+  sensitive   = true
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "pat" ? length(var.version_control_system_personal_access_token) > 0 : true
+    )
+    error_message = "Variable version_control_system_personal_access_token must be defined when version_control_system_authentication_method is pat."
+  }
 }
 
 variable "version_control_system_placeholder_agent_name" {

--- a/variables.version.control.system.tf
+++ b/variables.version.control.system.tf
@@ -67,7 +67,7 @@ variable "version_control_system_github_application_key" {
 
   validation {
     condition = (
-      var.version_control_system_authentication_method == "github_app" ? try(var.version_control_system_github_application_key, "") != "" : true
+      var.version_control_system_authentication_method == "github_app" ? var.version_control_system_github_application_key != "" && var.version_control_system_github_application_key != null : true
     )
     error_message = "Variable version_control_system_github_application_key must be defined when version_control_system_authentication_method is github_app."
   }
@@ -94,7 +94,7 @@ variable "version_control_system_personal_access_token" {
 
   validation {
     condition = (
-      var.version_control_system_authentication_method == "pat" ? try(var.version_control_system_personal_access_token, "") != "" : true
+      var.version_control_system_authentication_method == "pat" ? var.version_control_system_personal_access_token != "" && var.version_control_system_personal_access_token != null : true
     )
     error_message = "Variable version_control_system_personal_access_token must be defined when version_control_system_authentication_method is pat."
   }

--- a/variables.version.control.system.tf
+++ b/variables.version.control.system.tf
@@ -7,6 +7,68 @@ variable "version_control_system_personal_access_token" {
   type        = string
   description = "The personal access token for the version control system."
   sensitive   = true
+  default     = ""
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "pat" ? length(var.version_control_system_personal_access_token) > 0 : true
+    )
+    error_message = "Variable version_control_system_personal_access_token must be defined when version_control_system_authentication_method is pat."
+  }
+}
+
+variable "version_control_system_github_application_key" {
+  type        = string
+  description = "The application key for the GitHub App authentication method."
+  sensitive   = true
+  default     = ""
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_key) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_application_key must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_github_application_id" {
+  type        = string
+  default     = ""
+  description = "The application ID for the GitHub App authentication method."
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_id) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_application_id must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_github_installation_id" {
+  type        = string
+  default     = ""
+  description = "The installation ID for the GitHub App authentication method."
+
+  validation {
+    condition = (
+      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_installation_id) > 0 : true
+    )
+    error_message = "Variable version_control_system_github_installation_id must be defined when version_control_system_authentication_method is github_app."
+  }
+}
+
+variable "version_control_system_authentication_method" {
+  type        = string
+  default     = "pat"
+  description = "GitHub authentication method. Possible values: pat or github_app"
+
+  validation {
+    condition = (
+      var.version_control_system_type == "azuredevops" ? var.version_control_system_authentication_method == "pat" :
+      var.version_control_system_authentication_method == "pat" || var.version_control_system_authentication_method == "github_app"
+    )
+    error_message = "azuredevops and github both support only pat while github_app is only supported for github."
+  }
 }
 
 variable "version_control_system_type" {

--- a/variables.version.control.system.tf
+++ b/variables.version.control.system.tf
@@ -61,13 +61,13 @@ variable "version_control_system_github_application_id" {
 
 variable "version_control_system_github_application_key" {
   type        = string
-  default     = ""
+  default     = null
   description = "The application key for the GitHub App authentication method."
   sensitive   = true
 
   validation {
     condition = (
-      var.version_control_system_authentication_method == "github_app" ? length(var.version_control_system_github_application_key) > 0 : true
+      var.version_control_system_authentication_method == "github_app" ? try(var.version_control_system_github_application_key, "") != "" : true
     )
     error_message = "Variable version_control_system_github_application_key must be defined when version_control_system_authentication_method is github_app."
   }
@@ -88,13 +88,13 @@ variable "version_control_system_github_installation_id" {
 
 variable "version_control_system_personal_access_token" {
   type        = string
-  default     = ""
+  default     = null
   description = "The personal access token for the version control system."
   sensitive   = true
 
   validation {
     condition = (
-      var.version_control_system_authentication_method == "pat" ? length(var.version_control_system_personal_access_token) > 0 : true
+      var.version_control_system_authentication_method == "pat" ? try(var.version_control_system_personal_access_token, "") != "" : true
     )
     error_message = "Variable version_control_system_personal_access_token must be defined when version_control_system_authentication_method is pat."
   }


### PR DESCRIPTION
## Description
A part of https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners/issues/52

When version_control_system_type is "github" and compute_types is "azure_container_app", beside personal access token, github application can be now used as authentication method.

GitHub Application needs the following permissions:
- Repository: Actions (Read-only) and Administration (Read & Write).
- Organization: Self-hosted Runners (Read & write) 

Changes related to this feature are made in the following folders/files:
- example/github_basic
- exampe/github_public_networking
- README.md
- locals.container.app.job.tf
- variables.version.control.system.tf

Other changes are made by pre-commit check
 
## Type of Change
 * [ ]  Non-module change (e.g., CI/CD, documentation, etc.)
 * [ ]  Azure Verified Module updates:
   * [ ]  Bugfix containing backwards compatible bug fixes  
     * [ ]  Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
     * [ ]  The bug was found by the module author, and no one has opened an issue to report it yet.
   * [x]  Feature update backwards compatible feature updates.
   * [ ]  Breaking changes.
   * [x]  Update to documentation
 
# Checklist
 * [x]  I'm sure there are no other open Pull Requests for the same update/change
 * [x]  My corresponding pipelines / checks run clean and green without any errors or warnings
 * [x]  I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks