### PR TITLE
fix: use ACR subscription for roleDefinitionId to prevent drift

### DIFF
--- a/main.container.registry.tf
+++ b/main.container.registry.tf
@@ -26,7 +26,7 @@ resource "azapi_resource" "custom_container_registry_pull" {
   body = {
     properties = {
       principalId      = local.user_assigned_managed_identity_principal_id
-      roleDefinitionId = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/${local.role_definition_ids.acr_pull}"
+      roleDefinitionId = "/subscriptions/${split("/", var.custom_container_registry_id)[2]}/providers/Microsoft.Authorization/roleDefinitions/${local.role_definition_ids.acr_pull}"
       principalType    = "ServicePrincipal"
     }
   }


### PR DESCRIPTION


## Description
Using data.azapi_client_config.current.subscription_id for the roleDefinitionId causes an infinite drift: the provider subscription may differ from the ACR's subscription, but Azure always normalizes the roleDefinitionId to match the scope's subscription on read-back.

Extract the subscription directly from var.custom_container_registry_id so the configured value matches what Azure returns, eliminating the perpetual update on every plan.

Fixes #151 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
