### PR TITLE
fix: propagate tags to placeholder job to eliminate Azure Policy drift

### DIFF
--- a/modules/container-app-job/main.tf
+++ b/modules/container-app-job/main.tf
@@ -75,7 +75,7 @@ resource "azapi_resource" "placeholder" {
     }
   }
   retry = var.retry
-  tags  = null
+  tags  = var.tags
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
The placeholder job had tags = null hardcoded while azapi_resource.job already uses var.tags. Azure Policy stamps tags on the resource after each apply, causing perpetual drift and re-triggering placeholder_trigger.

## Description
Fixes #186
Closes #186

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #186
Closes #186
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #186" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
