### PR TITLE
fix: propogate tags to private endpoint to eliminate Azure Policy drift

### DIFF
--- a/modules/container-registry/main.tf
+++ b/modules/container-registry/main.tf
@@ -11,6 +11,7 @@ module "container_registry" {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zone_id == null || var.private_dns_zone_id == "" ? [] : [var.private_dns_zone_id]
       subnet_resource_id            = var.subnet_id
+      tags                          = var.tags
     }
   } : null
   public_network_access_enabled = !var.use_private_networking


### PR DESCRIPTION
This change ensures the container registry private endpoint receives the same tags as the rest of the deployment by passing var.tags into the module input. Without this, the private endpoint was created untagged, which triggered Azure Policy drift and non-compliance noise. Propagating the tags keeps the resource metadata consistent and removes the policy drift signal.

## Description

Partially Fixes #124  


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Partially Fixes #124 " in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
